### PR TITLE
feat(bom): add framework-specific external dependencies to BOM

### DIFF
--- a/cheshire-bom/pom.xml
+++ b/cheshire-bom/pom.xml
@@ -15,6 +15,28 @@
   <name>Cheshire :: Bill of Materials</name>
   <description>Bill of Materials (BOM) for cheshire framework dependencies</description>
 
+  <properties>
+    <!-- Framework-specific external dependency versions -->
+    <lombok.version>1.18.42</lombok.version>
+    <slf4j.version>2.0.17</slf4j.version>
+    <h2.version>2.4.240</h2.version>
+    <calcite.version>1.41.0</calcite.version>
+    <jooq.version>3.20.10</jooq.version>
+    <hikari.version>7.0.2</hikari.version>
+    <swagger.version>2.2.22</swagger.version>
+    <jackson.version>2.18.2</jackson.version>
+    <snakeyaml.version>2.2</snakeyaml.version>
+    <jetty.version>12.1.5</jetty.version>
+    <jakarta.servlet.version>6.1.0</jakarta.servlet.version>
+    <jakarta.websocket-api.version>2.1.0</jakarta.websocket-api.version>
+    <okhttp.version>4.12.0</okhttp.version>
+    <mcp.version>0.17.0</mcp.version>
+    <reactive-streams.version>1.0.4</reactive-streams.version>
+    <jetbrains.annotations.version>24.0.1</jetbrains.annotations.version>
+    <json-smart.version>2.5.2</json-smart.version>
+    <commons-lang3.version>3.20.0</commons-lang3.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
 
@@ -105,6 +127,167 @@
         <groupId>io.cheshire</groupId>
         <artifactId>dev-utils</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <!-- Framework-specific external dependencies -->
+      <!-- Lombok + Logging -->
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+
+      <!-- H2 (tests, examples, Calcite engine) -->
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>${h2.version}</version>
+      </dependency>
+
+      <!-- Apache Calcite (Calcite query engine) -->
+      <dependency>
+        <groupId>org.apache.calcite</groupId>
+        <artifactId>calcite-core</artifactId>
+        <version>${calcite.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.calcite</groupId>
+        <artifactId>calcite-linq4j</artifactId>
+        <version>${calcite.version}</version>
+      </dependency>
+
+      <!-- jOOQ -->
+      <dependency>
+        <groupId>org.jooq</groupId>
+        <artifactId>jooq</artifactId>
+        <version>${jooq.version}</version>
+      </dependency>
+
+      <!-- HikariCP (if/when used for pooling) -->
+      <dependency>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP</artifactId>
+        <version>${hikari.version}</version>
+      </dependency>
+
+      <!-- Swagger / OpenAPI -->
+      <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-core</artifactId>
+        <version>${swagger.version}</version>
+      </dependency>
+
+      <!-- Jackson -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <!-- Servlet support for Jetty 12 / Jakarta EE 10 -->
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-servlet</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-servlets</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.websocket</groupId>
+        <artifactId>jakarta.websocket-api</artifactId>
+        <version>${jakarta.websocket-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+        <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+        <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+        <artifactId>jetty-ee10-websocket-servlet</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+
+      <!-- okHttp 3 -->
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp.version}</version>
+      </dependency>
+
+      <!-- MCP -->
+      <dependency>
+        <groupId>io.modelcontextprotocol.sdk</groupId>
+        <artifactId>mcp</artifactId>
+        <version>${mcp.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.modelcontextprotocol.sdk</groupId>
+        <artifactId>mcp-core</artifactId>
+        <version>${mcp.version}</version>
+      </dependency>
+
+      <!-- Reactive Streams -->
+      <dependency>
+        <groupId>org.reactivestreams</groupId>
+        <artifactId>reactive-streams</artifactId>
+        <version>${reactive-streams.version}</version>
+      </dependency>
+
+      <!-- SnakeYAML -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${snakeyaml.version}</version>
+      </dependency>
+
+      <!-- JetBrains Annotations -->
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${jetbrains.annotations.version}</version>
+      </dependency>
+
+      <!-- Transitive dependency for calcite: https://www.mend.io/vulnerability-database/CVE-2024-57699 -->
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>${json-smart.version}</version>
+      </dependency>
+
+      <!-- Commons Lang3 -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
## Summary

Adds framework-specific external dependencies to the BOM to allow implementations to inherit consistent versions without explicit version tags.

## Changes

- Add properties section with all framework dependency versions
- Add lombok, slf4j, h2, calcite, jooq, hikari, swagger, jackson, jetty, okhttp, mcp, snakeyaml, jetbrains.annotations, json-smart, commons-lang3 to BOM

## Benefits

- Implementations can remove version tags from framework dependencies
- Ensures version consistency across all projects using the framework
- Transitive dependencies automatically use BOM versions