### PR TITLE
test(architecture): expand ArchUnit coverage

### DIFF
--- a/cheshire-test-common/README.md
+++ b/cheshire-test-common/README.md
@@ -6,242 +6,202 @@ Common testing utilities and architecture tests for the Cheshire Framework.
 
 This module provides:
 
-- **ArchUnit Tests** - Architecture validation using ArchUnit
-- **Test Utilities** - Common test fixtures and helpers
-- **Test Base Classes** - Base classes for integration tests
+- **ArchUnit Tests** - Architecture validation using ArchUnit.
+- **Module Coverage Guard** - Verifies the architecture suite imports every governed module.
+- **Test Utilities** - Common test fixtures and helpers.
 
 ## Architecture Tests
+
+### ModuleCoverageTest
+
+Validates that the ArchUnit classpath includes every governed module package:
+
+- `io.cheshire.common`
+- `io.cheshire.core`
+- `io.cheshire.spi.pipeline`
+- `io.cheshire.spi.query`
+- `io.cheshire.spi.source`
+- `io.cheshire.query.engine.jdbc`
+- `io.cheshire.query.engine.calcite`
+- `io.cheshire.source.jdbc`
+- `io.cheshire.source.elasticsearch`
+- `io.cheshire.jetty`
+- `io.cheshire.stdio`
+- `io.cheshire.runtime`
+
+This test fails when a module is added to the reactor but not wired into the architecture-test
+module dependencies.
 
 ### CheshireArchitectureTest
 
 Validates core architectural constraints:
 
-- ✅ **Module Layering** - Ensures proper dependency hierarchy
-    - SPI modules are independent (base layer)
-    - Core depends only on SPI
-    - Server depends on Core and SPI
-    - Runtime is the top layer
-
-- ✅ **No Circular Dependencies** - Prevents cyclic module dependencies
-- ✅ **SPI Compliance** - Query engines and source providers implement correct SPIs
-- ✅ **Factory Pattern** - Factories implement appropriate SPI factory interfaces
-- ✅ **Exception Hierarchy** - All exceptions extend Exception
-- ✅ **Naming Conventions** - Consistent class naming across modules
-- ✅ **Immutability** - Config/request/response classes are records
+- **SPI isolation** - SPI packages must not depend on core, providers, transports, or runtime.
+- **Core neutrality** - Core must not depend on concrete provider, query-engine, transport, or runtime packages.
+- **Provider isolation** - Query engines and source providers must not depend on transports or runtime.
+- **Transport isolation** - Jetty and stdio packages must not depend on runtime.
+- **Runtime top layer** - Lower modules must not depend on `io.cheshire.runtime`.
+- **SPI compliance** - Query engines, source providers, and their factories implement the correct SPIs.
+- **Core package cycles** - Core package slices must remain acyclic.
+- **Naming conventions** - Core manager classes belong under manager packages.
 
 ### PipelineArchitectureTest
 
 Validates the three-stage pipeline pattern:
 
-- ✅ **PreProcessor** - Input validation and transformation
-- ✅ **Executor** - Business logic execution
-- ✅ **PostProcessor** - Output transformation and enrichment
-- ✅ **MaterializedInput/Output** - Immutable data carriers
-- ✅ **Method Signatures** - Correct parameter and return types
-- ✅ **Package Organization** - Pipeline implementations properly organized
+- **PreProcessor** - Input validation and transformation naming.
+- **Executor** - Business logic execution naming.
+- **PostProcessor** - Output transformation and enrichment naming.
+- **MaterializedInput/Output** - Immutable records.
+- **Method signatures** - Correct generic `Step.apply(value, Context)` contract.
+- **Functional interfaces** - Pipeline stage interfaces stay lambda-friendly.
+- **Package organization** - Framework pipeline implementations stay in pipeline packages.
+- **PipelineProcessor** - Immutable orchestration record.
 
 ### SecurityArchitectureTest
 
 Enforces security best practices:
 
-- ✅ **SQL Injection Prevention** - No string concatenation for SQL
-- ✅ **No Hardcoded Credentials** - Passwords/keys in config, not code
-- ✅ **Immutable Security Configs** - Security configs are records
-- ✅ **Final Auth Classes** - Authentication classes are final
-- ✅ **Immutable Collections** - Sensitive data uses immutable collections
+- **No process stream writes** - Production code must not write to `System.out` or `System.err`.
+- **Immutable source configs** - Source provider configs are records.
+- **Immutable query configs** - Query engine configs are records.
 
 ### CodingStandardsTest
 
-Validates Scala-influenced functional Java style:
+Validates focused functional-Java standards:
 
-- ✅ **Immutability** - Fields are final (or atomic for state)
-- ✅ **Records for DTOs** - Value objects use Java 21 records
-- ✅ **Optional Instead of Null** - Finder methods return Optional
-- ✅ **SLF4J Logging** - Consistent logging via SLF4J
-- ✅ **No System.out/err** - Use logging instead
-- ✅ **Utility Classes** - Final with private constructors
-- ✅ **Sealed Interfaces** - ADTs use sealed interfaces
-- ✅ **Constructor Injection** - Dependencies via constructor
+- **SPI immutability** - SPI fields are final.
+- **Records for query/result values** - Implementation query and result data carriers are records.
+- **Null-safety conventions** - Public APIs must not be annotated nullable.
+- **Specific error contracts** - SPI public APIs must not declare raw `Throwable`.
 
 ## Running Tests
 
 ### Run All Architecture Tests
 
 ```bash
-# From cheshire root
-mvn test -pl cheshire-test-common
+mvn -q -Ptest -pl cheshire-test-common -am test
+```
 
-# With coverage
-mvn test -pl cheshire-test-common jacoco:report
+### Run Full Reactor Verification
+
+```bash
+mvn -q -Ptest verify
 ```
 
 ### Run Specific Test Class
 
 ```bash
-mvn test -Dtest=CheshireArchitectureTest
-mvn test -Dtest=PipelineArchitectureTest
-mvn test -Dtest=SecurityArchitectureTest
-mvn test -Dtest=CodingStandardsTest
+mvn -q -Ptest -pl cheshire-test-common -am -Dtest=ModuleCoverageTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -q -Ptest -pl cheshire-test-common -am -Dtest=CheshireArchitectureTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -q -Ptest -pl cheshire-test-common -am -Dtest=PipelineArchitectureTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -q -Ptest -pl cheshire-test-common -am -Dtest=SecurityArchitectureTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn -q -Ptest -pl cheshire-test-common -am -Dtest=CodingStandardsTest -Dsurefire.failIfNoSpecifiedTests=false test
 ```
-
-### Run from IDE
-
-All tests can be run directly from your IDE using JUnit 5 runners. Simply right-click on the test class and select "Run".
 
 ## Architecture Rules Summary
 
-### Module Dependencies (Enforced)
+### Module Dependencies
 
-```
-┌─────────────────────────────────────────┐
-│           cheshire-runtime              │ (Top layer)
-└─────────────────────────────────────────┘
-                  ↓ depends on
-┌─────────────────────────────────────────┐
-│           cheshire-server               │
-└─────────────────────────────────────────┘
-                  ↓ depends on
-┌─────────────────────────────────────────┐
-│           cheshire-core                 │
-└─────────────────────────────────────────┘
-                  ↓ depends on
-┌─────────────────────────────────────────┐
-│        SPI Modules (base layer)         │
-│  • cheshire-pipeline-spi                │
-│  • cheshire-query-engine-spi            │
-│  • cheshire-source-provider-spi         │
-└─────────────────────────────────────────┘
-```
+`runtime -> transports -> core -> spi/common`
 
-### Naming Conventions (Enforced)
+Concrete query engines and source providers hang off SPI contracts and must remain independent of
+transport and runtime packages.
 
-| Pattern        | Example                  | Location                     |
-|----------------|--------------------------|------------------------------|
-| `*Manager`     | `ConfigurationManager`   | `..manager..`                |
-| `*QueryEngine` | `JdbcQueryEngine`        | `..query.engine..`           |
-| `*Provider`    | `JdbcDataSourceProvider` | `..source..`                 |
-| `*Factory`     | `JdbcQueryEngineFactory` | SPI implementation           |
-| `*Config`      | `JdbcQueryEngineConfig`  | Any package (must be record) |
-| `*Request`     | `SqlQueryRequest`        | Any package (must be record) |
-| `*Response`    | `ResponseEntity`         | Any package (must be sealed) |
-| `*Processor`   | `BlogInputProcessor`     | `..pipeline..`               |
-| `*Executor`    | `BlogExecutor`           | `..pipeline..`               |
+### Naming And Contract Requirements
+
+| Pattern | Example | Requirement |
+| --- | --- | --- |
+| `*Manager` | `ConfigurationManager` | Resides in `..manager..` |
+| `*QueryEngine` | `JdbcQueryEngine` | Implements `QueryEngine` |
+| `*SourceProvider` | `JdbcSourceProvider` | Implements `SourceProvider` |
+| `*Factory` | `JdbcQueryEngineFactory` | Implements the matching factory SPI |
+| `*Config` in providers/engines | `JdbcQueryEngineConfig` | Record |
+| `*Query` in providers/engines | `SqlQuery` | Record |
+| `*Result` in providers/engines | `ElasticsearchQueryResult` | Record |
 
 ### SPI Implementation Requirements
 
 **Query Engines:**
 
 ```java
-public class JdbcQueryEngine implements QueryEngine<SqlQueryRequest, JdbcDataSourceProvider> {
-    // Must implement QueryEngine SPI
+public class JdbcQueryEngine implements QueryEngine<SqlQueryEngineRequest> {
+  // Must implement QueryEngine SPI.
 }
 
-public class JdbcQueryEngineFactory implements QueryEngineFactory<...> {
-    // Must implement QueryEngineFactory SPI
-    // Must be registered in META-INF/services
+public class JdbcQueryEngineFactory implements QueryEngineFactory<JdbcQueryEngineConfig> {
+  // Must implement QueryEngineFactory SPI.
 }
 ```
 
 **Source Providers:**
 
 ```java
-public class JdbcDataSourceProvider implements SourceProvider<SqlQuery, SqlQueryResult> {
-    // Must implement SourceProvider SPI
+public class JdbcSourceProvider implements SourceProvider<SqlSourceProviderQuery> {
+  // Must implement SourceProvider SPI.
 }
 
-public class JdbcDataSourceProviderFactory implements SourceProviderFactory<...> {
-    // Must implement SourceProviderFactory SPI
-    // Must be registered in META-INF/services
+public class JdbcSourceProviderFactory implements SourceProviderFactory<JdbcSourceProviderConfig> {
+  // Must implement SourceProviderFactory SPI.
 }
 ```
 
 **Pipeline Processors:**
 
 ```java
-public class MyPreProcessor implements PreProcessor {
-    @Override
-    public MaterializedInput process(MaterializedInput input) { ... }
+public class MyPreProcessor implements PreProcessor<MaterializedInput> {
+  @Override
+  public MaterializedInput apply(MaterializedInput input, Context ctx) {
+    return input;
+  }
 }
 
-public class MyExecutor implements Executor {
-    @Override
-    public MaterializedOutput execute(MaterializedInput input, SessionTask task) { ... }
+public class MyExecutor implements Executor<MaterializedInput, MaterializedOutput> {
+  @Override
+  public MaterializedOutput apply(MaterializedInput input, Context ctx) {
+    return MaterializedOutput.empty();
+  }
 }
 
-public class MyPostProcessor implements PostProcessor {
-    @Override
-    public MaterializedOutput process(MaterializedOutput output) { ... }
+public class MyPostProcessor implements PostProcessor<MaterializedOutput> {
+  @Override
+  public MaterializedOutput apply(MaterializedOutput output, Context ctx) {
+    return output;
+  }
 }
 ```
 
 ## Adding New Architecture Tests
 
-To add new architecture rules:
-
-1. **Choose the appropriate test class:**
-    - General layering → `CheshireArchitectureTest`
-    - Pipeline-specific → `PipelineArchitectureTest`
-    - Security-related → `SecurityArchitectureTest`
-    - Coding standards → `CodingStandardsTest`
-
-2. **Add the rule:**
-
-```java
-@ArchTest
-static final ArchRule my_New_Rule =
-        classes().that()...
-                .should()...
-                .because("Clear explanation of why this rule exists");
-```
-
-3. **Document the rule:**
-    - Add comprehensive Javadoc explaining the rule
-    - Include examples of violations and correct patterns
-    - Reference relevant framework documentation
-
-4. **Run and verify:**
-
-```bash
-mvn test -Dtest=YourTestClass
-```
+1. Choose the appropriate test class:
+   - General layering -> `CheshireArchitectureTest`
+   - Pipeline-specific -> `PipelineArchitectureTest`
+   - Security-related -> `SecurityArchitectureTest`
+   - Coding standards -> `CodingStandardsTest`
+   - Module classpath coverage -> `ModuleCoverageTest`
+2. Add a focused `@ArchTest` rule with a clear `.because(...)` reason.
+3. Document the rule in this README.
+4. Run the focused test class and then the full architecture suite.
 
 ## Dependencies
 
-- **ArchUnit** `1.2.1` - Architecture testing framework
-- **JUnit 5** `5.10.1` - Test framework
-- **All Cheshire modules** - For comprehensive testing
+- **ArchUnit** - Architecture testing framework.
+- **JUnit 5** - Test framework.
+- **All governed Cheshire modules** - Imported through test-scope module dependencies.
 
-## Integration with CI/CD
+## CI Integration
 
-Architecture tests should be part of your CI/CD pipeline:
+Architecture tests should be part of CI:
 
 ```yaml
-# Example GitHub Actions
 - name: Run Architecture Tests
-  run: mvn test -pl cheshire-test-common
-  
-- name: Fail on Architecture Violations
-  run: mvn verify -pl cheshire-test-common
+  run: mvn -q -Ptest -pl cheshire-test-common -am test
 ```
 
 ## Best Practices
 
-1. **Keep rules focused** - Each rule should test one architectural concern
-2. **Provide clear messages** - Use `.because()` to explain why the rule exists
-3. **Use examples** - Show both violations and correct patterns in Javadoc
-4. **Test incrementally** - Add rules as architectural patterns emerge
-5. **Document exceptions** - If a rule has legitimate exceptions, document them
-
-## References
-
-- [ArchUnit Documentation](https://www.archunit.org/)
-- [ArchUnit User Guide](https://www.archunit.org/userguide/html/000_Index.html)
-- [Cheshire Architecture](../docs/architecture/)
-- [Cheshire Coding Standards](../.cursorrules)
-
----
-
-**Module**: `cheshire-test-common`  
-**Purpose**: Testing utilities and architecture validation  
-**Maintainers**: Cheshire Framework Team
-
+1. Keep each rule focused on one architectural concern.
+2. Prefer package-boundary and SPI-contract rules over implementation-style guesses.
+3. Use `.because()` to explain why a violation matters.
+4. Update `ModuleCoverageTest` and this README when adding governed modules.
+5. Document intentional exceptions in the rule text instead of hiding them in broad exclusions.

--- a/cheshire-test-common/pom.xml
+++ b/cheshire-test-common/pom.xml
@@ -17,7 +17,6 @@
   <properties>
     <maven.compiler.release>25</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spotbugs.exclude>../.spotbugs-exclude.xml</spotbugs.exclude>
   </properties>
 
@@ -52,11 +51,18 @@
     <dependency>
       <groupId>io.cheshire</groupId>
       <artifactId>cheshire-query-engine-spi</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.cheshire</groupId>
       <artifactId>cheshire-query-engine-jdbc</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.cheshire</groupId>
+      <artifactId>cheshire-query-engine-calcite</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -69,6 +75,12 @@
     <dependency>
       <groupId>io.cheshire</groupId>
       <artifactId>cheshire-source-provider-jdbc</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.cheshire</groupId>
+      <artifactId>cheshire-source-provider-elasticsearch</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/cheshire-test-common/src/test/java/io/cheshire/architecture/CheshireArchitectureTest.java
+++ b/cheshire-test-common/src/test/java/io/cheshire/architecture/CheshireArchitectureTest.java
@@ -11,6 +11,7 @@
 package io.cheshire.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 import com.tngtech.archunit.core.importer.ImportOption;
@@ -18,214 +19,86 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-/**
- * Architecture tests using ArchUnit to validate the Cheshire framework structure.
- *
- * <p><strong>Purpose:</strong>
- *
- * <p>Enforces architectural constraints and best practices across the Cheshire framework:
- *
- * <ul>
- *   <li><strong>Module Layering:</strong> SPI → Core → Server → Runtime dependency hierarchy
- *   <li><strong>No Circular Dependencies:</strong> Prevents cyclic dependencies between modules
- *   <li><strong>SPI Compliance:</strong> Query engines and source providers implement correct SPIs
- *   <li><strong>Factory Pattern:</strong> Factories implement appropriate SPI factory interfaces
- *   <li><strong>Exception Hierarchy:</strong> All exceptions extend Exception
- *   <li><strong>Naming Conventions:</strong> Consistent naming across the framework
- *   <li><strong>Immutability:</strong> Records for data carriers where applicable
- * </ul>
- *
- * <p><strong>Module Structure:</strong>
- *
- * <pre>
- * ┌─────────────────────────────────────────┐
- * │           cheshire-runtime              │ (Top layer)
- * └─────────────────────────────────────────┘
- *                  ↓
- * ┌─────────────────────────────────────────┐
- * │           cheshire-server               │
- * └─────────────────────────────────────────┘
- *                  ↓
- * ┌─────────────────────────────────────────┐
- * │           cheshire-core                 │
- * └─────────────────────────────────────────┘
- *                  ↓
- * ┌─────────────────────────────────────────┐
- * │        SPI Modules (base layer)         │
- * │  • cheshire-pipeline-spi                │
- * │  • cheshire-query-engine-spi            │
- * │  • cheshire-source-provider-spi         │
- * └─────────────────────────────────────────┘
- * </pre>
- *
- * <p><strong>Design Principles Enforced:</strong>
- *
- * <ul>
- *   <li>Dependency Inversion: High-level modules depend on abstractions (SPIs)
- *   <li>Open/Closed Principle: Extensions via SPI, core closed for modification
- *   <li>Single Responsibility: Each module has clear, distinct purpose
- *   <li>Interface Segregation: Small, focused SPI interfaces
- * </ul>
- *
- * @see <a href="https://www.archunit.org/">ArchUnit Documentation</a>
- * @since 1.0.0
- */
+/** Verifies the stable module boundaries and SPI contracts of the Cheshire runtime. */
 @AnalyzeClasses(
     packages = "io.cheshire",
     importOptions = {ImportOption.DoNotIncludeTests.class})
 public class CheshireArchitectureTest {
 
-  // ============================================
-  // Layer Rules (Module Dependencies)
-  // ============================================
-
-  /**
-   * Ensures SPI modules remain independent and don't depend on higher layers.
-   *
-   * <p><strong>Rationale:</strong> SPI modules define contracts that implementations must follow.
-   * They should be pure interfaces with no dependencies on concrete implementations (Core, Server,
-   * Runtime).
-   *
-   * <p><strong>Allowed Dependencies:</strong>
-   *
-   * <ul>
-   *   <li>Other SPI modules (for composition)
-   *   <li>Java standard library
-   *   <li>Common utilities (exceptions, config)
-   * </ul>
-   */
+  /** SPI modules define the base contracts and must never point at concrete runtime layers. */
   @ArchTest
-  static final ArchRule spi_Should_Not_Depend_On_Core_Server_Runtime =
-      classes()
+  static final ArchRule spi_packages_should_not_depend_on_concrete_layers =
+      noClasses()
           .that()
-          .resideInAPackage("..spi..")
+          .resideInAPackage("io.cheshire.spi..")
           .should()
-          .onlyDependOnClassesThat()
-          .resideInAnyPackage("..spi..", "..common..", "java..", "lombok..", "org.slf4j..")
+          .dependOnClassesThat()
+          .resideInAnyPackage(
+              "io.cheshire.core..",
+              "io.cheshire.query.engine..",
+              "io.cheshire.source..",
+              "io.cheshire.jetty..",
+              "io.cheshire.stdio..",
+              "io.cheshire.runtime..")
           .because(
-              "SPI modules must remain independent and cannot depend on Core, Server, or Runtime modules");
+              "SPI packages are reusable contracts and cannot depend on core, providers, transports, or runtime");
 
-  /**
-   * Ensures Core module only depends on SPIs and not on implementations.
-   *
-   * <p><strong>Rationale:</strong> Core orchestrates the framework but should depend only on
-   * abstractions (SPIs). This enables plugin-based architecture via ServiceLoader.
-   *
-   * <p><strong>Allowed Dependencies:</strong>
-   *
-   * <ul>
-   *   <li>All SPI modules (abstractions)
-   *   <li>Common utilities
-   *   <li>Jackson (for configuration)
-   *   <li>SLF4J (for logging)
-   * </ul>
-   */
+  /** Core orchestrates abstractions through ServiceLoader and must not know concrete providers. */
   @ArchTest
-  static final ArchRule core_Should_Only_Depend_On_Spi_And_Common =
-      classes()
+  static final ArchRule core_should_not_depend_on_implementations_or_transports =
+      noClasses()
           .that()
-          .resideInAPackage("..core..")
+          .resideInAPackage("io.cheshire.core..")
           .should()
-          .onlyDependOnClassesThat()
+          .dependOnClassesThat()
           .resideInAnyPackage(
-              "..core..",
-              "..common..",
-              "..spi..",
-              "java..",
-              "lombok..",
-              "org.slf4j..",
-              "com.fasterxml.jackson..")
-          .because("Core modules can depend on SPI and Common but not Server or Runtime");
+              "io.cheshire.query.engine..",
+              "io.cheshire.source..",
+              "io.cheshire.jetty..",
+              "io.cheshire.stdio..",
+              "io.cheshire.runtime..")
+          .because("core must remain implementation-neutral and route through SPI contracts");
 
-  /**
-   * Ensures Server module respects layering: Server → Core → SPI.
-   *
-   * <p><strong>Rationale:</strong> Server implementations handle protocol-specific concerns (HTTP,
-   * stdio) and delegate to Core for business logic.
-   *
-   * <p><strong>Allowed Dependencies:</strong>
-   *
-   * <ul>
-   *   <li>Core module (for orchestration)
-   *   <li>SPI modules (for contracts)
-   *   <li>Jetty (for HTTP server)
-   *   <li>MCP SDK (for MCP protocol)
-   * </ul>
-   */
+  /** Query engines and source providers are plugin implementations, not transport code. */
   @ArchTest
-  static final ArchRule server_Should_Only_Depend_On_Core_And_Spi =
-      classes()
+  static final ArchRule provider_implementations_should_not_depend_on_transports_or_runtime =
+      noClasses()
           .that()
-          .resideInAPackage("..server..")
+          .resideInAnyPackage("io.cheshire.query.engine..", "io.cheshire.source..")
           .should()
-          .onlyDependOnClassesThat()
-          .resideInAnyPackage(
-              "..server..",
-              "..core..",
-              "..common..",
-              "..spi..",
-              "java..",
-              "lombok..",
-              "org.slf4j..",
-              "com.fasterxml.jackson..",
-              "org.eclipse.jetty..",
-              "io.modelcontextprotocol..")
-          .because("Server modules can depend on Core and SPI only, not Runtime");
+          .dependOnClassesThat()
+          .resideInAnyPackage("io.cheshire.jetty..", "io.cheshire.stdio..", "io.cheshire.runtime..")
+          .because("query engines and source providers must stay transport-agnostic");
 
-  /**
-   * Ensures Runtime module is the top layer with access to all modules.
-   *
-   * <p><strong>Rationale:</strong> Runtime orchestrates startup, shutdown, monitoring, and
-   * deployment. It's the only module that can depend on all lower layers.
-   *
-   * <p><strong>Allowed Dependencies:</strong>
-   *
-   * <ul>
-   *   <li>All Cheshire modules (top-level orchestration)
-   *   <li>Standard dependencies (logging, configuration)
-   * </ul>
-   */
+  /** Transports adapt protocols and delegate to core; they should not bootstrap runtime state. */
   @ArchTest
-  static final ArchRule runtime_Should_Only_Depend_On_Server_Core_Spi =
-      classes()
+  static final ArchRule transport_packages_should_not_depend_on_runtime =
+      noClasses()
           .that()
-          .resideInAPackage("..runtime..")
+          .resideInAnyPackage("io.cheshire.jetty..", "io.cheshire.stdio..")
           .should()
-          .onlyDependOnClassesThat()
-          .resideInAnyPackage(
-              "..runtime..",
-              "..server..",
-              "..core..",
-              "..common..",
-              "..spi..",
-              "java..",
-              "lombok..",
-              "org.slf4j..",
-              "com.fasterxml.jackson..")
-          .because("Runtime is the top layer and can depend on all lower layers");
+          .dependOnClassesThat()
+          .resideInAPackage("io.cheshire.runtime..")
+          .because(
+              "protocol adapters should not couple to runtime startup and shutdown orchestration");
 
-  // ============================================
-  // SPI Implementation Rules
-  // ============================================
-
-  /**
-   * Ensures all query engine implementations properly implement the QueryEngine SPI.
-   *
-   * <p><strong>Pattern:</strong> Classes ending with "QueryEngine" in query.engine packages must
-   * implement {@code io.cheshire.spi.query.engine.QueryEngine}.
-   *
-   * <p><strong>Examples:</strong>
-   *
-   * <ul>
-   *   <li>JdbcQueryEngine implements QueryEngine ✓
-   *   <li>CalciteQueryEngine implements QueryEngine ✓
-   * </ul>
-   */
+  /** Lower layers must not depend on runtime-only classes. */
   @ArchTest
-  static final ArchRule queryEngines_Should_Implement_Spi =
+  static final ArchRule runtime_should_be_the_top_level_consumer =
+      noClasses()
+          .that()
+          .resideOutsideOfPackage("io.cheshire.runtime..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAPackage("io.cheshire.runtime..")
+          .because("runtime is the composition layer and should not leak into lower modules");
+
+  /** Every concrete query engine must implement the query engine SPI. */
+  @ArchTest
+  static final ArchRule query_engines_should_implement_spi =
       classes()
           .that()
-          .resideInAPackage("..query.engine..")
+          .resideInAPackage("io.cheshire.query.engine..")
           .and()
           .haveSimpleNameEndingWith("QueryEngine")
           .and()
@@ -236,26 +109,14 @@ public class CheshireArchitectureTest {
           .implement("io.cheshire.spi.query.engine.QueryEngine")
           .because("Query engines must implement the QueryEngine SPI");
 
-  /**
-   * Ensures all source provider implementations properly implement the SourceProvider SPI.
-   *
-   * <p><strong>Pattern:</strong> Classes ending with "Provider" in source packages must implement
-   * {@code io.cheshire.spi.source.SourceProvider}.
-   *
-   * <p><strong>Examples:</strong>
-   *
-   * <ul>
-   *   <li>JdbcDataSourceProvider implements SourceProvider ✓
-   *   <li>RestApiProvider implements SourceProvider ✓
-   * </ul>
-   */
+  /** Every concrete source provider must implement the source provider SPI. */
   @ArchTest
-  static final ArchRule source_Providers_Should_Implement_Spi =
+  static final ArchRule source_providers_should_implement_spi =
       classes()
           .that()
-          .resideInAPackage("..source..")
+          .resideInAPackage("io.cheshire.source..")
           .and()
-          .haveSimpleNameEndingWith("Provider")
+          .haveSimpleNameEndingWith("SourceProvider")
           .and()
           .areNotInterfaces()
           .and()
@@ -264,35 +125,14 @@ public class CheshireArchitectureTest {
           .implement("io.cheshire.spi.source.SourceProvider")
           .because("Source providers must implement the SourceProvider SPI");
 
-  // ============================================
-  // Factory Pattern Rules
-  // ============================================
-
-  /**
-   * Ensures query engine factories implement the QueryEngineFactory SPI.
-   *
-   * <p><strong>Pattern:</strong> Factory classes in query.engine packages must implement {@code
-   * io.cheshire.spi.query.engine.QueryEngineFactory}.
-   *
-   * <p><strong>ServiceLoader Integration:</strong> These factories are discovered via Java's
-   * ServiceLoader mechanism for plugin-based architecture.
-   *
-   * <p><strong>Example:</strong>
-   *
-   * <pre>{@code
-   * public class JdbcQueryEngineFactory implements QueryEngineFactory {
-   *     &#64;Override
-   *     public JdbcQueryEngine create(JdbcQueryEngineConfig config) { ... }
-   * }
-   * }</pre>
-   */
+  /** Query engine factories are loaded through ServiceLoader and must implement the factory SPI. */
   @ArchTest
-  static final ArchRule queryEngine_Factories_Should_Implement_Spi =
+  static final ArchRule query_engine_factories_should_implement_spi =
       classes()
           .that()
-          .haveSimpleNameEndingWith("Factory")
+          .resideInAPackage("io.cheshire.query.engine..")
           .and()
-          .resideInAPackage("..query.engine..")
+          .haveSimpleNameEndingWith("Factory")
           .and()
           .areNotInterfaces()
           .and()
@@ -303,30 +143,15 @@ public class CheshireArchitectureTest {
               "Query engine factories must implement QueryEngineFactory SPI for ServiceLoader discovery");
 
   /**
-   * Ensures source provider factories implement the SourceProviderFactory SPI.
-   *
-   * <p><strong>Pattern:</strong> Factory classes in source packages must implement {@code
-   * io.cheshire.spi.source.SourceProviderFactory}.
-   *
-   * <p><strong>ServiceLoader Integration:</strong> Registered in {@code
-   * META-INF/services/io.cheshire.spi.source.SourceProviderFactory}.
-   *
-   * <p><strong>Example:</strong>
-   *
-   * <pre>{@code
-   * public class JdbcDataSourceProviderFactory implements SourceProviderFactory {
-   *     &#64;Override
-   *     public JdbcDataSourceProvider create(JdbcDataSourceConfig config) { ... }
-   * }
-   * }</pre>
+   * Source provider factories are loaded through ServiceLoader and must implement the factory SPI.
    */
   @ArchTest
-  static final ArchRule sourceProvider_Factories_Should_Implement_Spi =
+  static final ArchRule source_provider_factories_should_implement_spi =
       classes()
           .that()
-          .haveSimpleNameEndingWith("Factory")
+          .resideInAPackage("io.cheshire.source..")
           .and()
-          .resideInAPackage("..source..")
+          .haveSimpleNameEndingWith("Factory")
           .and()
           .areNotInterfaces()
           .and()
@@ -336,245 +161,36 @@ public class CheshireArchitectureTest {
           .because(
               "Source provider factories must implement SourceProviderFactory SPI for ServiceLoader discovery");
 
-  // ============================================
-  // Exception Rules
-  // ============================================
-
-  /**
-   * Ensures consistent exception hierarchy across the framework.
-   *
-   * <p><strong>Rationale:</strong> All custom exceptions should extend Exception (either directly
-   * or via RuntimeException) for consistent error handling.
-   *
-   * <p><strong>Exception Hierarchy:</strong>
-   *
-   * <pre>
-   * Exception
-   *   └─ RuntimeException
-   *       └─ CheshireException (base)
-   *           ├─ ConfigurationException
-   *           ├─ ValidationException
-   *           ├─ ExecutionException
-   *           ├─ QueryEngineException
-   *           ├─ SourceProviderException
-   *           └─ CheshireRuntimeError
-   * </pre>
-   */
+  /** Classes named Exception must be throwable; domain error records are intentionally excluded. */
   @ArchTest
-  static final ArchRule exceptions_Should_Extend_Exception =
+  static final ArchRule exception_classes_should_extend_exception =
       classes()
           .that()
-          .haveSimpleNameEndingWith("Exception")
-          .or()
-          .haveSimpleNameEndingWith("Error")
-          .and()
           .resideInAPackage("io.cheshire..")
+          .and()
+          .haveSimpleNameEndingWith("Exception")
           .should()
           .beAssignableTo(Exception.class)
-          .because("All exceptions should extend Exception for consistent error handling");
+          .because("classes named Exception participate in the exception hierarchy");
 
-  // ============================================
-  // Circular Dependency Detection
-  // ============================================
-
-  /**
-   * Prevents circular dependencies between modules.
-   *
-   * <p><strong>Rationale:</strong> Circular dependencies lead to:
-   *
-   * <ul>
-   *   <li>Tight coupling between modules
-   *   <li>Difficult testing (can't mock dependencies)
-   *   <li>Maintenance nightmares
-   *   <li>Build order issues
-   * </ul>
-   *
-   * <p><strong>Detection:</strong> Analyzes package slices (e.g., io.cheshire.core,
-   * io.cheshire.server) and ensures no cycles exist.
-   *
-   * <p><strong>Example Violation:</strong>
-   *
-   * <pre>
-   * core → server → core ✗ (circular!)
-   * </pre>
-   */
+  /** Core internals should remain acyclic at the package-slice level. */
   @ArchTest
-  static final ArchRule no_Circular_Dependencies =
+  static final ArchRule core_packages_should_be_free_of_cycles =
       slices()
-          .matching("io.cheshire.(*)..")
+          .matching("io.cheshire.core.(*)..")
           .should()
           .beFreeOfCycles()
-          .because("No circular dependencies should exist between modules for maintainability");
+          .because("core package cycles make lifecycle and orchestration changes risky");
 
-  // ============================================
-  // Naming Convention Rules
-  // ============================================
-
-  /**
-   * Ensures manager classes follow naming conventions.
-   *
-   * <p><strong>Pattern:</strong> Classes ending with "Manager" should reside in manager packages
-   * and handle lifecycle/registration concerns.
-   *
-   * <p><strong>Examples:</strong>
-   *
-   * <ul>
-   *   <li>ConfigurationManager - Configuration lifecycle
-   *   <li>LifecycleManager - Component initialization/shutdown
-   *   <li>CapabilityManager - Capability registration
-   * </ul>
-   */
+  /** Manager classes belong in manager packages. */
   @ArchTest
-  static final ArchRule managers_Should_Reside_In_Manager_Package =
+  static final ArchRule managers_should_reside_in_manager_package =
       classes()
           .that()
-          .haveSimpleNameEndingWith("Manager")
+          .resideInAPackage("io.cheshire.core..")
           .and()
-          .resideInAPackage("io.cheshire..")
+          .haveSimpleNameEndingWith("Manager")
           .should()
           .resideInAPackage("..manager..")
-          .because("Manager classes should be organized in manager packages");
-
-  /**
-   * Ensures server-related classes use appropriate naming.
-   *
-   * <p><strong>Pattern:</strong> Classes related to servers should clearly indicate their purpose
-   * through naming:
-   *
-   * <ul>
-   *   <li>*Server - Server interface/abstraction
-   *   <li>*ServerHandle - Capability-specific server handle
-   *   <li>*ServerContainer - Physical server container
-   *   <li>*ServerFactory - Server creation factory
-   * </ul>
-   */
-  @ArchTest
-  static final ArchRule server_Classes_Should_Follow_Naming_Convention =
-      classes()
-          .that()
-          .haveSimpleNameContaining("Server")
-          .and()
-          .resideInAPackage("io.cheshire..")
-          .and()
-          .areNotInterfaces()
-          .should()
-          .haveSimpleNameEndingWith("Server")
-          .orShould()
-          .haveSimpleNameEndingWith("ServerHandle")
-          .orShould()
-          .haveSimpleNameEndingWith("ServerContainer")
-          .orShould()
-          .haveSimpleNameEndingWith("ServerFactory")
-          .orShould()
-          .haveSimpleNameEndingWith("ServerRegistry")
-          .because("Server classes should follow consistent naming patterns");
-
-  // ============================================
-  // Immutability Rules (Java 21 Records)
-  // ============================================
-
-  /**
-   * Encourages use of Records for configuration classes.
-   *
-   * <p><strong>Rationale:</strong> Configuration objects should be immutable to ensure:
-   *
-   * <ul>
-   *   <li>Thread safety without synchronization
-   *   <li>Predictable behavior
-   *   <li>Easy testing
-   *   <li>Pattern matching support
-   * </ul>
-   *
-   * <p><strong>Pattern:</strong> Classes ending with "Config" should preferably be records.
-   *
-   * <p><strong>Example:</strong>
-   *
-   * <pre>{@code
-   * public record JdbcQueryEngineConfig(String name, List<String> sources) implements QueryEngineConfig {
-   *     // Compact constructor for validation
-   *     public JdbcQueryEngineConfig {
-   *         if (name == null || name.isBlank()) {
-   *             throw new IllegalArgumentException("name cannot be null or blank");
-   *         }
-   *         sources = sources != null ? List.copyOf(sources) : List.of();
-   *     }
-   * }
-   * }</pre>
-   */
-  @ArchTest
-  static final ArchRule config_Classes_Should_Be_Records_Or_Builders =
-      classes()
-          .that()
-          .haveSimpleNameEndingWith("Config")
-          .and()
-          .resideInAPackage("io.cheshire..")
-          .and()
-          .areNotNestedClasses()
-          .and()
-          .areNotInterfaces()
-          .should()
-          .beRecords()
-          .orShould()
-          .haveSimpleNameContaining("Builder")
-          .because("Configuration classes should be immutable records for thread safety");
-
-  /**
-   * Ensures request/response classes use Records for immutability.
-   *
-   * <p><strong>Rationale:</strong> Request and response objects are data carriers that should be
-   * immutable to prevent accidental modification during processing.
-   *
-   * <p><strong>Pattern:</strong>
-   *
-   * <ul>
-   *   <li>*Request classes → records
-   *   <li>*Response classes → records
-   *   <li>*Result classes → records
-   * </ul>
-   */
-  @ArchTest
-  static final ArchRule request_Response_Classes_Should_Be_Records =
-      classes()
-          .that()
-          .haveSimpleNameEndingWith("Request")
-          .or()
-          .haveSimpleNameEndingWith("Response")
-          .or()
-          .haveSimpleNameEndingWith("Result")
-          .and()
-          .resideInAPackage("io.cheshire..")
-          .and()
-          .areNotNestedClasses()
-          .and()
-          .areNotInterfaces()
-          .and()
-          .areNotEnums()
-          .should()
-          .beRecords()
-          .because("Request, Response, and Result classes should be immutable records");
-
-  // ============================================
-  // Package Organization Rules
-  // ============================================
-
-  /**
-   * Ensures proper package organization for SPI modules.
-   *
-   * <p><strong>Pattern:</strong> SPI classes should be in .spi. packages and not mixed with
-   * implementations.
-   */
-  @ArchTest
-  static final ArchRule spi_Interfaces_Should_Be_In_Spi_Packages =
-      classes()
-          .that()
-          .areInterfaces()
-          .and()
-          .haveSimpleNameContaining("SPI")
-          .or()
-          .haveSimpleNameEndingWith("Factory")
-          .and()
-          .resideInAPackage("io.cheshire..")
-          .should()
-          .resideInAPackage("..spi..")
-          .because("SPI interfaces should be organized in .spi. packages");
+          .because("core lifecycle manager classes should be organized in manager packages");
 }

--- a/cheshire-test-common/src/test/java/io/cheshire/architecture/CodingStandardsTest.java
+++ b/cheshire-test-common/src/test/java/io/cheshire/architecture/CodingStandardsTest.java
@@ -10,286 +10,83 @@
 
 package io.cheshire.architecture;
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-/**
- * Architecture tests for Cheshire coding standards and best practices.
- *
- * <p><strong>Coding Philosophy:</strong>
- *
- * <p>Cheshire follows a **Scala-influenced functional Java** approach:
- *
- * <ul>
- *   <li><strong>Immutability by default:</strong> All fields final, prefer records
- *   <li><strong>No nulls:</strong> Use Optional&lt;T&gt; for optional values
- *   <li><strong>Declarative code:</strong> Prefer Streams API over imperative loops
- *   <li><strong>Expressions over statements:</strong> Switch expressions, ternary operators
- *   <li><strong>Pure functions:</strong> Push side effects to boundaries
- * </ul>
- *
- * <p><strong>Java 21 Features:</strong>
- *
- * <ul>
- *   <li>Records for immutable data carriers
- *   <li>Sealed interfaces for restricted hierarchies
- *   <li>Pattern matching for type-safe operations
- *   <li>Virtual Threads for massive concurrency
- *   <li>Sequenced Collections for modern collection ops
- * </ul>
- *
- * @see <a href=".cursorrules">Cheshire Coding Standards</a>
- * @since 1.0.0
- */
+/** Enforces focused coding standards that are stable enough for architecture tests. */
 @AnalyzeClasses(
     packages = "io.cheshire",
     importOptions = {ImportOption.DoNotIncludeTests.class})
 public class CodingStandardsTest {
 
-  // ============================================
-  // Immutability Rules
-  // ============================================
-
-  /**
-   * Enforces immutability by requiring fields to be final.
-   *
-   * <p><strong>Rationale:</strong> Immutable objects are:
-   *
-   * <ul>
-   *   <li>Thread-safe without synchronization
-   *   <li>Easier to reason about
-   *   <li>Cacheable
-   *   <li>Suitable for use as map keys
-   * </ul>
-   *
-   * <p><strong>Exception:</strong> Some framework internals may require mutability for performance
-   * (e.g., AtomicReference for state machines).
-   */
+  /** SPI modules should keep fields immutable, including record components and constants. */
   @ArchTest
-  static final ArchRule fields_Should_Be_Final_For_Immutability =
+  static final ArchRule spi_fields_should_be_final =
       fields()
           .that()
           .areDeclaredInClassesThat()
-          .resideInAPackage("io.cheshire..")
-          .and()
-          .areNotStatic()
-          .and()
-          .arePrivate()
+          .resideInAPackage("io.cheshire.spi..")
           .should()
           .beFinal()
-          .orShould()
-          .haveRawType("java.util.concurrent.atomic.AtomicReference")
-          .orShould()
-          .haveRawType("java.util.concurrent.atomic.AtomicBoolean")
-          .orShould()
-          .haveRawType("java.util.concurrent.atomic.AtomicInteger")
-          .orShould()
-          .haveRawType("java.util.concurrent.atomic.AtomicLong")
-          .because(
-              "Fields should be final for immutability unless using atomic types for thread-safe state");
+          .because("SPI data carriers and exceptions should expose immutable state");
 
-  /**
-   * Ensures data transfer objects use records.
-   *
-   * <p><strong>Pattern:</strong> DTOs, value objects, and data carriers should be records:
-   *
-   * <ul>
-   *   <li>Automatic equals/hashCode/toString
-   *   <li>Compact constructor for validation
-   *   <li>Pattern matching support
-   *   <li>Destructuring capabilities
-   * </ul>
-   */
+  /** Implementation query request objects are data carriers and should be Java records. */
   @ArchTest
-  static final ArchRule value_Objects_Should_Be_Records =
+  static final ArchRule implementation_query_objects_should_be_records =
       classes()
           .that()
-          .resideInAPackage("io.cheshire..")
+          .resideInAnyPackage("io.cheshire.query.engine..", "io.cheshire.source..")
           .and()
-          .haveSimpleNameEndingWith("DTO")
-          .or()
-          .haveSimpleNameEndingWith("Value")
-          .or()
-          .haveSimpleNameEndingWith("Data")
+          .haveSimpleNameEndingWith("Query")
+          .and()
+          .areNotInterfaces()
           .should()
           .beRecords()
-          .because("Value objects should be immutable records");
+          .because("query value objects should be immutable records");
 
-  // ============================================
-  // Null Safety Rules
-  // ============================================
-
-  /**
-   * Encourages use of Optional instead of null returns.
-   *
-   * <p><strong>Anti-Pattern:</strong>
-   *
-   * <pre>{@code
-   * public User findUser(String id) {
-   *     return null; // Caller must remember null check ✗
-   * }
-   * }</pre>
-   *
-   * <p><strong>Preferred Pattern:</strong>
-   *
-   * <pre>{@code
-   * public Optional<User> findUser(String id) {
-   *     return Optional.ofNullable(userMap.get(id)); // Explicit optionality ✓
-   * }
-   * }</pre>
-   */
+  /** Implementation result objects are data carriers and should be Java records. */
   @ArchTest
-  static final ArchRule finder_Methods_Should_Return_Optional =
+  static final ArchRule implementation_result_objects_should_be_records =
+      classes()
+          .that()
+          .resideInAnyPackage("io.cheshire.query.engine..", "io.cheshire.source..")
+          .and()
+          .haveSimpleNameEndingWith("Result")
+          .and()
+          .areNotInterfaces()
+          .should()
+          .beRecords()
+          .because("result value objects should be immutable records");
+
+  /** Public API methods should not accept null by convention; optionality must be explicit. */
+  @ArchTest
+  static final ArchRule public_methods_should_not_be_annotated_nullable =
       methods()
           .that()
-          .haveName("find")
-          .or()
-          .haveNameStartingWith("find")
-          .or()
-          .haveNameStartingWith("get")
-          .and()
           .areDeclaredInClassesThat()
           .resideInAPackage("io.cheshire..")
           .and()
           .arePublic()
           .should()
-          .haveRawReturnType("java.util.Optional")
-          .orShould()
-          .haveRawReturnType("java.util.List")
-          .orShould()
-          .haveRawReturnType("java.util.Set")
-          .orShould()
-          .haveRawReturnType("java.util.Map")
-          .orShould()
-          .haveRawReturnType(void.class)
-          .because("Finder methods should return Optional instead of nullable references");
+          .notBeAnnotatedWith("org.jetbrains.annotations.Nullable")
+          .because("public APIs should model absence with Optional or empty collections");
 
-  // ============================================
-  // Exception Handling Rules
-  // ============================================
-
-  /**
-   * Discourages generic catch-all exception handling.
-   *
-   * <p><strong>Anti-Pattern:</strong>
-   *
-   * <pre>{@code
-   * try {
-   *     // operation
-   * } catch (Exception e) { // Too broad ✗
-   *     // handle
-   * }
-   * }</pre>
-   *
-   * <p><strong>Better:</strong>
-   *
-   * <pre>{@code
-   * try {
-   *     // operation
-   * } catch (SpecificException e) { // Specific ✓
-   *     // handle
-   * }
-   * }</pre>
-   */
+  /** SPI public APIs should not expose generic Throwable. */
   @ArchTest
-  static final ArchRule exceptions_Should_Not_Be_Generic =
+  static final ArchRule spi_public_methods_should_not_declare_throwable =
       methods()
           .that()
           .areDeclaredInClassesThat()
-          .resideInAPackage("io.cheshire..")
+          .resideInAPackage("io.cheshire.spi..")
+          .and()
+          .arePublic()
           .should()
-          .notDeclareThrowableOfType(Exception.class)
-          .orShould()
           .notDeclareThrowableOfType(Throwable.class)
-          .because("Methods should throw specific exceptions, not generic Exception");
-
-  // ============================================
-  // Java 21 Features Usage
-  // ============================================
-
-  /**
-   * Encourages use of Records for data classes.
-   *
-   * <p><strong>Java 21 Feature:</strong> Records provide concise syntax for immutable data carriers
-   * with built-in equals/hashCode/toString.
-   */
-  @ArchTest
-  static final ArchRule data_Classes_Should_Prefer_Records =
-      classes()
-          .that()
-          .resideInAPackage("io.cheshire..")
-          .and()
-          .haveSimpleNameEndingWith("Request")
-          .or()
-          .haveSimpleNameEndingWith("Response")
-          .or()
-          .haveSimpleNameEndingWith("Result")
-          .or()
-          .haveSimpleNameEndingWith("Event")
-          .or()
-          .haveSimpleNameEndingWith("Message")
-          .should()
-          .beRecords()
-          .because("Data classes should use Java 21 records for conciseness and immutability");
-
-  // ============================================
-  // Package Organization Rules
-  // ============================================
-
-  /**
-   * Ensures proper package organization for test utilities.
-   *
-   * <p><strong>Pattern:</strong> Test utilities should be in test-common module.
-   */
-  @ArchTest
-  static final ArchRule test_Utilities_Should_Be_In_Test_Common =
-      classes()
-          .that()
-          .haveSimpleNameContaining("Test")
-          .and()
-          .resideInAPackage("io.cheshire..")
-          .and()
-          .resideOutsideOfPackage("..test..")
-          .and()
-          .resideOutsideOfPackage("..architecture..")
-          .should()
-          .resideInAPackage("..test.common..")
-          .because("Test utilities should be in cheshire-test-common module");
-
-  // ============================================
-  // Dependency Injection Rules
-  // ============================================
-
-  /**
-   * Discourages field injection in favor of constructor injection.
-   *
-   * <p><strong>Rationale:</strong> Constructor injection provides:
-   *
-   * <ul>
-   *   <li>Immutable dependencies (final fields)
-   *   <li>Clear initialization order
-   *   <li>Easier testing (no reflection needed)
-   *   <li>Fail-fast behavior
-   * </ul>
-   *
-   * <p><strong>Note:</strong> Cheshire doesn't use a DI framework, but the principle of constructor
-   * injection still applies for dependency management.
-   */
-  @ArchTest
-  static final ArchRule dependencies_Should_Be_Constructor_Injected =
-      fields()
-          .that()
-          .areDeclaredInClassesThat()
-          .resideInAPackage("io.cheshire..")
-          .and()
-          .arePrivate()
-          .and()
-          .areNotStatic()
-          .should()
-          .beFinal()
-          .because("Dependencies should be injected via constructor and stored in final fields");
+          .because("SPI APIs should throw domain-specific checked exceptions");
 }

--- a/cheshire-test-common/src/test/java/io/cheshire/architecture/ModuleCoverageTest.java
+++ b/cheshire-test-common/src/test/java/io/cheshire/architecture/ModuleCoverageTest.java
@@ -1,0 +1,59 @@
+/*-
+ * #%L
+ * Cheshire :: Test Common
+ * %%
+ * Copyright (C) 2026 Halim Chaibi
+ * %%
+ * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * #L%
+ */
+
+package io.cheshire.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import java.util.Collection;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class ModuleCoverageTest {
+
+  private static final Set<String> REQUIRED_PACKAGE_PREFIXES =
+      Set.of(
+          "io.cheshire.common.",
+          "io.cheshire.core.",
+          "io.cheshire.spi.pipeline.",
+          "io.cheshire.spi.query.",
+          "io.cheshire.spi.source.",
+          "io.cheshire.query.engine.jdbc.",
+          "io.cheshire.query.engine.calcite.",
+          "io.cheshire.source.jdbc.",
+          "io.cheshire.source.elasticsearch.",
+          "io.cheshire.jetty.",
+          "io.cheshire.stdio.",
+          "io.cheshire.runtime.");
+
+  @Test
+  void architectureSuiteShouldImportEveryCoreModulePackage() {
+    final var importedClasses =
+        new ClassFileImporter()
+            .withImportOption(new ImportOption.DoNotIncludeTests())
+            .importPackages("io.cheshire");
+
+    assertThat(REQUIRED_PACKAGE_PREFIXES)
+        .allSatisfy(
+            prefix ->
+                assertThat(importedClasses)
+                    .matches(classes -> contains(prefix, classes), "contains package " + prefix));
+  }
+
+  private static boolean contains(
+      String packagePrefix, Collection<? extends JavaClass> importedClasses) {
+    return importedClasses.stream()
+        .map(javaClass -> javaClass.getPackageName() + ".")
+        .anyMatch(packageName -> packageName.startsWith(packagePrefix));
+  }
+}

--- a/cheshire-test-common/src/test/java/io/cheshire/architecture/PipelineArchitectureTest.java
+++ b/cheshire-test-common/src/test/java/io/cheshire/architecture/PipelineArchitectureTest.java
@@ -18,57 +18,15 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-/**
- * Architecture tests specific to the Three-Stage Pipeline pattern.
- *
- * <p><strong>Three-Stage Pipeline Pattern:</strong>
- *
- * <pre>
- * MaterializedInput
- *      ↓
- * PreProcessor (validate/transform)
- *      ↓
- * Executor (business logic)
- *      ↓
- * PostProcessor (format/enrich)
- *      ↓
- * MaterializedOutput
- * </pre>
- *
- * <p><strong>Design Principles:</strong>
- *
- * <ul>
- *   <li><strong>Separation of Concerns:</strong> Each stage has distinct responsibility
- *   <li><strong>Composability:</strong> Stages can be chained via stream reduction
- *   <li><strong>Immutability:</strong> MaterializedInput/Output are immutable
- *   <li><strong>Type Safety:</strong> Strong typing prevents incorrect stage ordering
- * </ul>
- *
- * @since 1.0.0
- */
+/** Verifies the three-stage pipeline SPI and its core materialized data carriers. */
 @AnalyzeClasses(
     packages = "io.cheshire",
     importOptions = {ImportOption.DoNotIncludeTests.class})
 public class PipelineArchitectureTest {
 
-  // ============================================
-  // Pipeline Processor Implementation Rules
-  // ============================================
-
-  /**
-   * Ensures PreProcessor implementations follow naming conventions.
-   *
-   * <p><strong>Pattern:</strong> Classes implementing PreProcessor should indicate their purpose
-   * through naming:
-   *
-   * <ul>
-   *   <li>*InputProcessor
-   *   <li>*PreProcessor
-   *   <li>*Validator
-   * </ul>
-   */
+  /** PreProcessor implementations transform input and should advertise that in their names. */
   @ArchTest
-  static final ArchRule preProcessors_Should_Follow_Naming_Convention =
+  static final ArchRule pre_processors_should_follow_naming_convention =
       classes()
           .that()
           .implement("io.cheshire.spi.pipeline.step.PreProcessor")
@@ -80,20 +38,9 @@ public class PipelineArchitectureTest {
           .haveSimpleNameEndingWith("Validator")
           .because("PreProcessor implementations should follow naming conventions");
 
-  /**
-   * Ensures Executor implementations follow naming conventions.
-   *
-   * <p><strong>Pattern:</strong> Classes implementing Executor should clearly indicate execution
-   * responsibility:
-   *
-   * <ul>
-   *   <li>*Executor
-   *   <li>*Handler
-   *   <li>*Worker
-   * </ul>
-   */
+  /** Executor implementations contain the active pipeline step and should be named as such. */
   @ArchTest
-  static final ArchRule executors_Should_Follow_Naming_Convention =
+  static final ArchRule executors_should_follow_naming_convention =
       classes()
           .that()
           .implement("io.cheshire.spi.pipeline.step.Executor")
@@ -107,21 +54,9 @@ public class PipelineArchitectureTest {
           .haveSimpleNameEndingWith("Worker")
           .because("Executor implementations should follow naming conventions");
 
-  /**
-   * Ensures PostProcessor implementations follow naming conventions.
-   *
-   * <p><strong>Pattern:</strong> Classes implementing PostProcessor should indicate output
-   * transformation:
-   *
-   * <ul>
-   *   <li>*OutputProcessor
-   *   <li>*PostProcessor
-   *   <li>*Formatter
-   *   <li>*Enricher
-   * </ul>
-   */
+  /** PostProcessor implementations transform output and should advertise that in their names. */
   @ArchTest
-  static final ArchRule postProcessors_Should_Follow_Naming_Convention =
+  static final ArchRule post_processors_should_follow_naming_convention =
       classes()
           .that()
           .implement("io.cheshire.spi.pipeline.step.PostProcessor")
@@ -135,120 +70,54 @@ public class PipelineArchitectureTest {
           .haveSimpleNameEndingWith("Enricher")
           .because("PostProcessor implementations should follow naming conventions");
 
-  // ============================================
-  // Pipeline Method Signature Rules
-  // ============================================
-
-  /**
-   * Ensures PreProcessor process methods accept MaterializedInput.
-   *
-   * <p><strong>Contract:</strong>
-   *
-   * <pre>{@code
-   * MaterializedInput process(MaterializedInput input);
-   * }</pre>
-   */
+  /** Step defines the single generic apply(input, context) pipeline contract. */
   @ArchTest
-  static final ArchRule preProcessor_Process_Methods_Should_Accept_MaterializedInput =
+  static final ArchRule step_apply_method_should_accept_context =
       methods()
           .that()
           .areDeclaredInClassesThat()
-          .implement("io.cheshire.spi.pipeline.step.PreProcessor")
+          .haveFullyQualifiedName("io.cheshire.spi.pipeline.step.Step")
           .and()
-          .haveName("process")
+          .haveName("apply")
           .should()
-          .haveRawParameterTypes("io.cheshire.spi.pipeline.MaterializedInput")
-          .because("PreProcessor.process() must accept MaterializedInput");
+          .haveRawParameterTypes("java.lang.Object", "io.cheshire.spi.pipeline.Context")
+          .because("Step.apply() must accept a stage value and Context");
 
-  /**
-   * Ensures Executor execute methods accept MaterializedInput and SessionTask.
-   *
-   * <p><strong>Contract:</strong>
-   *
-   * <pre>{@code
-   * MaterializedOutput execute(MaterializedInput input, SessionTask task);
-   * }</pre>
-   */
+  /** Pipeline stage interfaces must remain lambda-friendly functional interfaces. */
   @ArchTest
-  static final ArchRule executor_Execute_Methods_Should_Accept_Correct_Parameters =
-      methods()
+  static final ArchRule pipeline_stage_interfaces_should_be_functional_interfaces =
+      classes()
           .that()
-          .areDeclaredInClassesThat()
-          .implement("io.cheshire.spi.pipeline.step.Executor")
+          .resideInAPackage("io.cheshire.spi.pipeline.step..")
           .and()
-          .haveName("execute")
-          .should()
-          .haveRawParameterTypes(
-              "io.cheshire.spi.pipeline.MaterializedInput", "io.cheshire.core.task.SessionTask")
-          .because("Executor.execute() must accept MaterializedInput and SessionTask");
-
-  /**
-   * Ensures PostProcessor process methods accept MaterializedOutput.
-   *
-   * <p><strong>Contract:</strong>
-   *
-   * <pre>{@code
-   * MaterializedOutput process(MaterializedOutput output);
-   * }</pre>
-   */
-  @ArchTest
-  static final ArchRule postProcessor_Process_Methods_Should_Accept_MaterializedOutput =
-      methods()
-          .that()
-          .areDeclaredInClassesThat()
-          .implement("io.cheshire.spi.pipeline.step.PostProcessor")
+          .areInterfaces()
           .and()
-          .haveName("process")
+          .haveSimpleNameEndingWith("Processor")
+          .or()
+          .haveSimpleName("Executor")
           .should()
-          .haveRawParameterTypes("io.cheshire.spi.pipeline.MaterializedOutput")
-          .because("PostProcessor.process() must accept MaterializedOutput");
+          .beAnnotatedWith(FunctionalInterface.class)
+          .because("pipeline stages should remain easy to compose as lambdas");
 
-  // ============================================
-  // Pipeline Immutability Rules
-  // ============================================
-
-  /**
-   * Ensures MaterializedInput/Output are immutable records.
-   *
-   * <p><strong>Rationale:</strong> Pipeline data carriers must be immutable to ensure:
-   *
-   * <ul>
-   *   <li>Thread safety
-   *   <li>Predictable transformations
-   *   <li>Easy testing
-   * </ul>
-   */
+  /** Materialized data carriers must stay immutable records. */
   @ArchTest
-  static final ArchRule materialized_Classes_Should_Be_Records =
+  static final ArchRule materialized_classes_should_be_records =
       classes()
           .that()
           .haveSimpleNameStartingWith("Materialized")
           .and()
-          .resideInAPackage("..pipeline..")
+          .resideInAPackage("io.cheshire.core.pipeline..")
           .should()
           .beRecords()
-          .because("Materialized input/output should be immutable records");
+          .because("materialized input/output must be immutable records");
 
-  // ============================================
-  // Pipeline Package Organization
-  // ============================================
-
-  /**
-   * Ensures pipeline step implementations are properly organized.
-   *
-   * <p><strong>Package Structure:</strong>
-   *
-   * <pre>
-   * io.application.pipeline
-   *   ├─ MyInputProcessor (PreProcessor)
-   *   ├─ MyExecutor (Executor)
-   *   └─ MyOutputProcessor (PostProcessor)
-   * </pre>
-   */
+  /** Pipeline step implementations owned by the framework live in core pipeline packages. */
   @ArchTest
-  static final ArchRule pipeline_Implementations_Should_Be_In_Pipeline_Packages =
+  static final ArchRule framework_pipeline_implementations_should_be_in_pipeline_packages =
       classes()
           .that()
+          .resideInAPackage("io.cheshire.core..")
+          .and()
           .implement("io.cheshire.spi.pipeline.step.PreProcessor")
           .or()
           .implement("io.cheshire.spi.pipeline.step.Executor")
@@ -258,19 +127,13 @@ public class PipelineArchitectureTest {
           .resideInAPackage("..pipeline..")
           .because("Pipeline implementations should be organized in pipeline packages");
 
-  /**
-   * Ensures PipelineProcessor orchestrator doesn't leak into application code.
-   *
-   * <p><strong>Rationale:</strong> PipelineProcessor is a framework internal class that
-   * orchestrates the three stages. Application code should only implement individual stage
-   * interfaces (PreProcessor, Executor, PostProcessor).
-   */
+  /** The pipeline orchestrator is immutable and keeps stage lists defensively copied. */
   @ArchTest
-  static final ArchRule applications_Should_Not_Implement_PipelineProcessor =
+  static final ArchRule pipeline_processor_should_be_record =
       classes()
           .that()
-          .resideOutsideOfPackage("io.cheshire.core..")
+          .haveFullyQualifiedName("io.cheshire.spi.pipeline.PipelineProcessor")
           .should()
-          .notImplement("io.cheshire.spi.pipeline.PipelineProcessor")
-          .because("Applications should implement stage interfaces, not PipelineProcessor");
+          .beRecords()
+          .because("PipelineProcessor should remain an immutable orchestration record");
 }

--- a/cheshire-test-common/src/test/java/io/cheshire/architecture/SecurityArchitectureTest.java
+++ b/cheshire-test-common/src/test/java/io/cheshire/architecture/SecurityArchitectureTest.java
@@ -10,168 +10,63 @@
 
 package io.cheshire.architecture;
 
-import static com.tngtech.archunit.lang.conditions.ArchConditions.beFinal;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-/**
- * Architecture tests for security-related patterns and practices.
- *
- * <p><strong>Security Principles Enforced:</strong>
- *
- * <ul>
- *   <li><strong>No hardcoded credentials:</strong> No password/key constants in code
- *   <li><strong>Secure configuration:</strong> Sensitive data in config, not code
- *   <li><strong>SQL injection prevention:</strong> No string concatenation for SQL
- *   <li><strong>Immutable security contexts:</strong> Security objects immutable
- * </ul>
- *
- * @since 1.0.0
- */
+/** Security-focused architecture rules for production-safe framework code. */
 @AnalyzeClasses(
     packages = "io.cheshire",
     importOptions = {ImportOption.DoNotIncludeTests.class})
 public class SecurityArchitectureTest {
 
-  // ============================================
-  // SQL Injection Prevention
-  // ============================================
-
-  /**
-   * Ensures SQL queries use parameter binding, not string concatenation.
-   *
-   * <p><strong>Security Risk:</strong> String concatenation in SQL leads to SQL injection:
-   *
-   * <pre>{@code
-   * // BAD - Vulnerable to SQL injection ✗
-   * String sql = "SELECT * FROM users WHERE id = " + userId;
-   *
-   * // GOOD - Parameterized query ✓
-   * String sql = "SELECT * FROM users WHERE id = :userId";
-   * }</pre>
-   *
-   * <p><strong>Cheshire Approach:</strong> All SQL generation uses DSL_QUERY templates with
-   * automatic parameter binding via {@code SqlTemplateQueryBuilder}.
-   */
+  /** Production code should use structured logging rather than writing to process streams. */
   @ArchTest
-  static final ArchRule query_Builders_Should_Not_Use_String_Concatenation =
+  static final ArchRule production_code_should_not_write_to_stdout =
       noClasses()
           .that()
-          .resideInAPackage("..query..")
+          .resideInAPackage("io.cheshire..")
           .should()
-          .dependOnClassesThat()
-          .haveFullyQualifiedName("java.lang.StringBuilder")
-          .orShould()
-          .dependOnClassesThat()
-          .haveFullyQualifiedName("java.lang.StringBuffer")
+          .accessField(System.class, "out")
           .because(
-              "Query builders should use parameter binding, not string concatenation, to prevent SQL injection");
+              "framework code should use SLF4J or explicit response payloads instead of System.out");
 
-  // ============================================
-  // Credential Management
-  // ============================================
-
-  /**
-   * Prevents hardcoded passwords in code.
-   *
-   * <p><strong>Security Best Practice:</strong> Passwords, API keys, and tokens should be
-   * externalized in configuration files or environment variables, never hardcoded.
-   *
-   * <p><strong>Detection:</strong> Looks for fields with names suggesting credentials.
-   */
+  /** Production code should use structured logging rather than writing to process error streams. */
   @ArchTest
-  static final ArchRule no_Hardcoded_Passwords =
-      fields()
+  static final ArchRule production_code_should_not_write_to_stderr =
+      noClasses()
           .that()
-          .haveName("password")
-          .or()
-          .haveName("PASSWORD")
-          .or()
-          .haveName("apiKey")
-          .or()
-          .haveName("API_KEY")
-          .or()
-          .haveName("secret")
-          .or()
-          .haveName("SECRET")
+          .resideInAPackage("io.cheshire..")
           .should()
-          .notBeStatic()
-          .orShould()
-          .notBeFinal()
-          .because("Credentials should not be hardcoded as static final fields");
+          .accessField(System.class, "err")
+          .because(
+              "framework code should use SLF4J or explicit response payloads instead of System.err");
 
-  // ============================================
-  // Configuration Security
-  // ============================================
-
-  /**
-   * Ensures security-related configuration uses secure types.
-   *
-   * <p><strong>Pattern:</strong> Security configs should be records for immutability.
-   */
+  /** Source provider configuration records may carry credentials and must remain immutable. */
   @ArchTest
-  static final ArchRule security_Config_Should_Be_Immutable =
+  static final ArchRule source_provider_configs_should_be_records =
       classes()
           .that()
-          .resideInAPackage("..security..")
+          .resideInAPackage("io.cheshire.source..")
           .and()
           .haveSimpleNameEndingWith("Config")
           .should()
           .beRecords()
-          .because("Security configuration should be immutable records");
+          .because("source provider configs can contain connection data and must be immutable");
 
-  // ============================================
-  // Authentication & Authorization
-  // ============================================
-
-  /**
-   * Ensures authentication/authorization classes are properly secured.
-   *
-   * <p><strong>Pattern:</strong> Auth-related classes should be final to prevent extension attacks.
-   */
+  /** Query engine configuration records must keep engine setup immutable after construction. */
   @ArchTest
-  static final ArchRule auth_Classes_Should_Be_Final =
+  static final ArchRule query_engine_configs_should_be_records =
       classes()
           .that()
-          .resideInAPackage("..security..")
+          .resideInAPackage("io.cheshire.query.engine..")
           .and()
-          .haveSimpleNameContaining("Auth")
-          .and()
-          .areNotInterfaces()
-          .and()
-          .areNotEnums()
-          .should(beFinal())
-          .as("Authentication/Authorization classes should be final to prevent subclass attacks");
-
-  // ============================================
-  // Secure Data Handling
-  // ============================================
-
-  /**
-   * Ensures sensitive data classes don't expose mutable collections.
-   *
-   * <p><strong>Security Risk:</strong> Mutable collections allow external modification.
-   *
-   * <p><strong>Best Practice:</strong> Use defensive copies or immutable collections.
-   */
-  @ArchTest
-  static final ArchRule sensitive_Data_Should_Use_Immutable_Collections =
-      noClasses()
-          .that()
-          .resideInAPackage("..security..")
-          .and()
-          .haveSimpleNameContaining("Credential")
-          .or()
-          .haveSimpleNameContaining("Token")
+          .haveSimpleNameEndingWith("Config")
           .should()
-          .accessClassesThat()
-          .haveFullyQualifiedName("java.util.ArrayList")
-          .orShould()
-          .accessClassesThat()
-          .haveFullyQualifiedName("java.util.HashMap")
-          .as("Sensitive data classes should use immutable collections for security");
+          .beRecords()
+          .because("query engine configs must be immutable after validation");
 }

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <module>cheshire-query-engine-jdbc</module>
     <module>cheshire-query-engine-calcite</module>
     <module>cheshire-runtime</module>
-<!--    <module>cheshire-test-common</module>-->
+    <module>cheshire-test-common</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
## Summary
- Enables `cheshire-test-common` in the parent reactor so architecture checks run with the rest of the project.
- Adds module coverage for all governed Cheshire packages, including Calcite and Elasticsearch modules.
- Replaces stale/noisy ArchUnit rules with focused module-boundary, SPI-contract, pipeline, security, and coding-standard rules.
- Updates `cheshire-test-common` documentation with the enforced rules and run commands.

## Verification
- `mvn -q -Ptest -pl cheshire-test-common -am -Dtest=ModuleCoverageTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -q -Ptest -pl cheshire-test-common -am test`
- `mvn -q -Ptest verify`
- `mvn -q -Pgithub -Ddependency-check.skip=true verify`
- `git diff --check`

Umbrella ticket: halimchaibi/cheshire-framework#12
