### PR TITLE
feat(calcite): add DSL query support

### DIFF
--- a/cheshire-query-engine-calcite/src/main/java/io/cheshire/query/engine/calcite/CalciteQueryEngine.java
+++ b/cheshire-query-engine-calcite/src/main/java/io/cheshire/query/engine/calcite/CalciteQueryEngine.java
@@ -18,6 +18,7 @@ import io.cheshire.query.engine.calcite.executor.QueryExecutor;
 import io.cheshire.query.engine.calcite.optimizer.QueryRuntimeContext;
 import io.cheshire.query.engine.calcite.optimizer.RuleSetBuilder;
 import io.cheshire.query.engine.calcite.optimizer.RuleSetManager;
+import io.cheshire.query.engine.calcite.query.DslQuery;
 import io.cheshire.query.engine.calcite.query.QueryPlanCache;
 import io.cheshire.query.engine.calcite.schema.SchemaManager;
 import io.cheshire.query.engine.calcite.transformer.ResultTransformer;
@@ -155,7 +156,7 @@ public class CalciteQueryEngine implements QueryEngine<LogicalQuery> {
   public boolean validate(final LogicalQuery query) throws QueryEngineException {
     ensureOpen();
     try {
-      final String sql = ObjectUtils.requireObjectAs(query.query(), String.class);
+      final String sql = sqlFor(query);
       final Planner planner = new CalcitePlanner(frameworkConfig);
       try {
         final SqlNode parsed = planner.parse(sql);
@@ -259,7 +260,7 @@ public class CalciteQueryEngine implements QueryEngine<LogicalQuery> {
       final QueryRuntimeContext runtimeContext,
       final QueryEngineContext context)
       throws Exception {
-    final String sql = ObjectUtils.requireObjectAs(logicalQuery.query(), String.class);
+    final String sql = sqlFor(logicalQuery);
     final QueryEngineContext executionContext =
         Optional.ofNullable(context).orElseGet(QueryEngineContext::empty);
     final RuleSetManager ruleSet = buildQueryRuleSet(executionContext);
@@ -279,6 +280,13 @@ public class CalciteQueryEngine implements QueryEngine<LogicalQuery> {
     } finally {
       planner.close();
     }
+  }
+
+  private String sqlFor(final LogicalQuery logicalQuery) {
+    return switch (logicalQuery) {
+      case DslQuery dslQuery -> dslQuery.toSql();
+      default -> ObjectUtils.requireObjectAs(logicalQuery.query(), String.class);
+    };
   }
 
   private record PlannedQuery(RelNode relNode) {}

--- a/cheshire-query-engine-calcite/src/main/java/io/cheshire/query/engine/calcite/query/CalciteLogicalQuery.java
+++ b/cheshire-query-engine-calcite/src/main/java/io/cheshire/query/engine/calcite/query/CalciteLogicalQuery.java
@@ -12,4 +12,4 @@ package io.cheshire.query.engine.calcite.query;
 
 import io.cheshire.spi.query.request.LogicalQuery;
 
-public sealed interface CalciteLogicalQuery extends LogicalQuery permits SqlQuery {}
+public sealed interface CalciteLogicalQuery extends LogicalQuery permits DslQuery, SqlQuery {}

--- a/cheshire-query-engine-calcite/src/main/java/io/cheshire/query/engine/calcite/query/DslQuery.java
+++ b/cheshire-query-engine-calcite/src/main/java/io/cheshire/query/engine/calcite/query/DslQuery.java
@@ -1,0 +1,68 @@
+/*-
+ * #%L
+ * Cheshire :: Query Engine :: Calcite
+ * %%
+ * Copyright (C) 2026 Halim Chaibi
+ * %%
+ * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * #L%
+ */
+
+package io.cheshire.query.engine.calcite.query;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public record DslQuery(List<String> select, String from, Map<String, Object> parameters)
+    implements CalciteLogicalQuery {
+
+  public DslQuery {
+    select = normalizeSelect(select);
+    from = Objects.requireNonNull(from, "from must not be null").trim();
+    parameters = Map.copyOf(Objects.requireNonNull(parameters, "parameters must not be null"));
+  }
+
+  public static DslQuery select(String projection) {
+    return new DslQuery(List.of(projection), "", Map.of());
+  }
+
+  public DslQuery from(String source) {
+    return new DslQuery(select, source, parameters);
+  }
+
+  public String toSql() {
+    final String projection = String.join(", ", select);
+    return from.isBlank() ? "SELECT " + projection : "SELECT " + projection + " FROM " + from;
+  }
+
+  @Override
+  public Map<String, Object> query() {
+    final Map<String, Object> dsl = new LinkedHashMap<>();
+    dsl.put("select", select);
+    if (!from.isBlank()) {
+      dsl.put("from", from);
+    }
+    return Map.copyOf(dsl);
+  }
+
+  @Override
+  public boolean hasParameters() {
+    return !parameters.isEmpty();
+  }
+
+  private static List<String> normalizeSelect(List<String> select) {
+    final List<String> projections =
+        Objects.requireNonNull(select, "select must not be null").stream()
+            .map(projection -> Objects.requireNonNull(projection, "projection must not be null"))
+            .map(String::trim)
+            .toList();
+
+    if (projections.isEmpty() || projections.stream().anyMatch(String::isBlank)) {
+      throw new IllegalArgumentException("select must contain at least one non-blank projection");
+    }
+
+    return List.copyOf(projections);
+  }
+}

--- a/cheshire-query-engine-calcite/src/test/java/io/cheshire/query/engine/calcite/CalciteQueryEngineContractTest.java
+++ b/cheshire-query-engine-calcite/src/test/java/io/cheshire/query/engine/calcite/CalciteQueryEngineContractTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.cheshire.query.engine.calcite.config.CalciteQueryEngineConfig;
+import io.cheshire.query.engine.calcite.query.DslQuery;
 import io.cheshire.query.engine.calcite.query.SqlQuery;
 import io.cheshire.spi.query.exception.QueryEngineConfigurationException;
 import io.cheshire.spi.query.exception.QueryEngineException;
@@ -37,6 +38,25 @@ class CalciteQueryEngineContractTest {
   void explainReturnsRelationalPlanForValidSql() throws QueryEngineException {
     try (CalciteQueryEngine engine = openedEngine("calcite-contract-explain")) {
       final String plan = engine.explain(new SqlQuery("SELECT 1 AS x", Map.of()));
+
+      assertAll(
+          () -> assertFalse(plan.isBlank()),
+          () -> assertTrue(plan.contains("Logical"), plan),
+          () -> assertTrue(plan.contains("1"), plan));
+    }
+  }
+
+  @Test
+  void validateAcceptsDslQuery() throws QueryEngineException {
+    try (CalciteQueryEngine engine = openedEngine("calcite-contract-dsl-validation")) {
+      assertTrue(engine.validate(DslQuery.select("1 AS x")));
+    }
+  }
+
+  @Test
+  void explainReturnsRelationalPlanForDslQuery() throws QueryEngineException {
+    try (CalciteQueryEngine engine = openedEngine("calcite-contract-dsl-explain")) {
+      final String plan = engine.explain(DslQuery.select("1 AS x"));
 
       assertAll(
           () -> assertFalse(plan.isBlank()),

--- a/cheshire-query-engine-calcite/src/test/java/io/cheshire/query/engine/calcite/query/DslQueryTest.java
+++ b/cheshire-query-engine-calcite/src/test/java/io/cheshire/query/engine/calcite/query/DslQueryTest.java
@@ -1,0 +1,57 @@
+/*-
+ * #%L
+ * Cheshire :: Query Engine :: Calcite
+ * %%
+ * Copyright (C) 2026 Halim Chaibi
+ * %%
+ * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * #L%
+ */
+
+package io.cheshire.query.engine.calcite.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DslQueryTest {
+
+  @Test
+  void selectBuildsSqlForProjectionOnlyQuery() {
+    final DslQuery query = DslQuery.select("1 AS x");
+
+    assertThat(query.toSql()).isEqualTo("SELECT 1 AS x");
+    assertThat(query.query()).isEqualTo(Map.of("select", query.select()));
+  }
+
+  @Test
+  void fromAddsSourceWithoutMutatingOriginalQuery() {
+    final DslQuery projection = DslQuery.select("name");
+    final DslQuery sourced = projection.from("authors");
+
+    assertThat(projection.toSql()).isEqualTo("SELECT name");
+    assertThat(sourced.toSql()).isEqualTo("SELECT name FROM authors");
+  }
+
+  @Test
+  void constructorDefensivelyCopiesCollections() {
+    final var select = new ArrayList<String>();
+    select.add("name");
+
+    final DslQuery query = new DslQuery(select, "authors", Map.of("limit", 10));
+    select.add("email");
+
+    assertThat(query.select()).containsExactly("name");
+    assertThat(query.parameters()).containsExactlyEntriesOf(Map.of("limit", 10));
+  }
+
+  @Test
+  void constructorRejectsBlankProjection() {
+    assertThatThrownBy(() -> DslQuery.select(" "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("select");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `DslQuery` as a sealed Calcite logical-query subtype with immutable projection/source/parameter state.
- Teaches `CalciteQueryEngine` to translate `DslQuery` to SQL while preserving existing SQL-string query behavior.
- Adds contract coverage for Calcite validation/explain with DSL queries and unit coverage for DSL immutability and SQL rendering.

## Why
This is the first concrete slice for umbrella issue halimchaibi/cheshire-framework#26: Calcite now has more than one logical query representation to support the move toward method-level query polymorphism.

## Verification
- `mvn -q -Ptest -pl cheshire-query-engine-calcite -am -Dtest=CalciteQueryEngineContractTest,DslQueryTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`
- `mvn -q -Ptest verify`
